### PR TITLE
Add the option to fetch provider pacts with a specified tag

### DIFF
--- a/pact-jvm-provider-sbt/README.md
+++ b/pact-jvm-provider-sbt/README.md
@@ -126,6 +126,21 @@ SbtProviderPlugin.config ++ Seq(
 )
 ```
 
+
+You can also verify all the latest pacts for a provider for all its consumer where pacts have a specified tag:
+
+
+```scala
+import au.com.dius.pact.provider.sbt._
+SbtProviderPlugin.config ++ Seq(
+  providers := Seq(
+    ProviderConfig(name = "Our Service")
+        .hasPactsFromPactBroker(new URL("http://pact-broker.local"), "tagName"))
+)
+```
+
+Working with tags requires pact-broker >= v1.12.0.
+
 ### Filtering the interactions that are verified
 
 You can filter the interactions that are run using three properties: `pact.filter.consumers`, `pact.filter.description` and `pact.filter.providerState`.

--- a/pact-jvm-provider-sbt/src/main/scala/au/com/dius/pact/provider/sbt/SbtProviderPlugin.scala
+++ b/pact-jvm-provider-sbt/src/main/scala/au/com/dius/pact/provider/sbt/SbtProviderPlugin.scala
@@ -49,7 +49,7 @@ case class ConsumersFromDirectory(dir: File,
                                   verificationType: PactVerification = PactVerification.REQUST_RESPONSE,
                                   packagesToScan: List[String] = List()
                           ) extends ConsumerConfigInfo
-case class ConsumersFromPactBroker(pactBrokerUrl: URL) extends ConsumerConfigInfo
+case class ConsumersFromPactBroker(pactBrokerUrl: URL, tag: String = None) extends ConsumerConfigInfo
 
 case class ProviderConfig(protocol: String = "http",
                           host: String = "localhost",
@@ -86,8 +86,8 @@ case class ProviderConfig(protocol: String = "http",
     this
   }
 
-  def hasPactsFromPactBroker(pactBrokerUrl: URL) = {
-    consumers += ConsumersFromPactBroker(pactBrokerUrl)
+  def hasPactsFromPactBroker(pactBrokerUrl: URL, tag: String = None) = {
+    consumers += ConsumersFromPactBroker(pactBrokerUrl, tag)
     this
   }
 
@@ -133,7 +133,8 @@ object Verification {
       case dir: ConsumersFromDirectory => provInfo.getConsumers.addAll(
         ProviderUtils.loadPactFiles(provInfo, dir.dir, dir.stateChange.orNull, dir.stateChangeUsesBody,
         dir.verificationType, JavaConversions.seqAsJavaList(dir.packagesToScan)).asInstanceOf[util.List[ConsumerInfo]])
-      case ConsumersFromPactBroker(pactBrokerUrl) => provInfo.hasPactsFromPactBroker(pactBrokerUrl.toString)
+      case ConsumersFromPactBroker(pactBrokerUrl, None) => provInfo.hasPactsFromPactBroker(pactBrokerUrl.toString)
+      case ConsumersFromPactBroker(pactBrokerUrl, tag) => provInfo.hasPactsFromPactBrokerWithTag(pactBrokerUrl.toString, tag)
     }
 
     provInfo

--- a/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ProviderInfo.groovy
+++ b/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ProviderInfo.groovy
@@ -65,6 +65,13 @@ class ProviderInfo {
       consumersFromBroker
     }
 
+    List hasPactsFromPactBrokerWithTag(Map options = [:], String pactBrokerUrl, String tag) {
+        PactBrokerClient client = new PactBrokerClient(pactBrokerUrl, options)
+        def consumersFromBroker = client.fetchConsumersWithTag(name, tag)
+        consumers.addAll(consumersFromBroker)
+        consumersFromBroker
+    }
+
     @SuppressWarnings('ThrowRuntimeException')
     private List setupConsumerListFromPactFiles(ConsumersGroup consumersGroup) {
         if (!consumersGroup.pactFileLocation) {

--- a/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/broker/PactBrokerClient.groovy
+++ b/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/broker/PactBrokerClient.groovy
@@ -31,6 +31,20 @@ class PactBrokerClient {
     consumers
   }
 
+  List fetchConsumersWithTag(String provider, String tag) {
+    List consumers = []
+
+    HalClient halClient = newHalClient()
+      halClient.navigate('pb:latest-provider-pacts-with-tag', provider: provider, tag: tag).pacts { pact ->
+        consumers << new ConsumerInfo(pact.name, new URL(pact.href))
+      if (options.authentication) {
+        consumers.last().pactFileAuthentication = options.authentication
+      }
+    }
+
+    consumers
+  }
+
   private newHalClient() {
     new HalClient(pactBrokerUrl, options)
   }


### PR DESCRIPTION
@alonpeer, @dmt - could you please review?

We have been also thinking about wrapping ```halClient.navigate('pb:latest-provider-pacts-with-tag', provider: provider, tag: tag)``` in ```fetchConsumersWithTag``` method into ```try/catch``` and appending an exception with a meaningful message that ```Your Pact Broker may be not up to date to support 'pb:latest-provider-pacts-with-tag'``` link. @alonpeer - what do you think about it? Would you say it is needed/desired to have?

Thanks!